### PR TITLE
Potential fix for code scanning alert no. 9: Disabled Spring CSRF protection

### DIFF
--- a/backend-java/src/main/java/com/appunture/backend/config/SecurityConfig.java
+++ b/backend-java/src/main/java/com/appunture/backend/config/SecurityConfig.java
@@ -38,7 +38,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/api/auth/**")
+                )
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**", "/api/points/**", "/api/symptoms/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/actuator/health").permitAll()


### PR DESCRIPTION
Potential fix for [https://github.com/Appunture-2025/appunture-dev/security/code-scanning/9](https://github.com/Appunture-2025/appunture-dev/security/code-scanning/9)

To fix the problem, CSRF protection should not be globally disabled. Instead, CSRF protection should be enabled by default, and if there are specific endpoints (such as public APIs or authentication endpoints) that need to be excluded from CSRF protection, they should be explicitly configured using `csrf.ignoringRequestMatchers(...)`. This approach maintains CSRF protection for the rest of the application while allowing exceptions for endpoints that are safe to exclude (e.g., stateless authentication endpoints).

**Steps to fix:**
- Remove `.csrf(csrf -> csrf.disable())` from the security configuration.
- If there are endpoints that must be excluded from CSRF protection (such as `/api/auth/**`), configure them using `csrf.ignoringRequestMatchers(...)`.
- Ensure that CSRF protection remains enabled for all other endpoints.

**Required changes:**
- Edit the `securityFilterChain` method in `SecurityConfig.java` to remove the global CSRF disable.
- Optionally, add `.csrf(csrf -> csrf.ignoringRequestMatchers("/api/auth/**"))` if you want to exclude authentication endpoints from CSRF protection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
